### PR TITLE
Update EnhancedCache.gs

### DIFF
--- a/EnhancedCacheService/EnhancedCache.gs
+++ b/EnhancedCacheService/EnhancedCache.gs
@@ -34,7 +34,9 @@ function EnhancedCache(cache) {
    */
   this.remove = function(key) {
     var valueDescriptor = getValueDescriptor(key);
-    if (valueDescriptor.keys) {
+    if (valueDescriptor=== null){
+      return null
+      }else if(valueDescriptor.keys) {
       for (var i = 0; i < valueDescriptor.keys.length; i++) {
         var k = valueDescriptor.keys[i];
         remove_(k);


### PR DESCRIPTION
Was receiving error when trying to remove cache which no longer existed. 
`TypeError: Cannot read property 'keys' of null
at EnhancedCache.remove (src/EnhancedCache:37)`

Added handler for `null`  `valueDescriptor`  when cache no longer exists.